### PR TITLE
Remove mesa-gu gl=glx option which is no longer defined.

### DIFF
--- a/almalinux9/packages.yaml
+++ b/almalinux9/packages.yaml
@@ -316,7 +316,7 @@ packages:
       prefix: /usr
   mesa-glu:
     externals:
-    - spec: "mesa-glu gl=glx @9.0.1 %gcc@11 os=almalinux9"
+    - spec: "mesa-glu @9.0.1 %gcc@11 os=almalinux9"
       prefix: /usr
     buildable: False
   mesa:


### PR DESCRIPTION
@marcmengel 