### PR TITLE
remove %gcc@version from external specs

### DIFF
--- a/almalinux9/packages.yaml
+++ b/almalinux9/packages.yaml
@@ -1,10 +1,5 @@
 packages:
   all:
-    compiler:
-      - gcc@11
-      - clang@15.0.7
-      - gcc
-      - clang
     target:
       - x86_64_v2
     providers:
@@ -53,130 +48,130 @@ packages:
     require: bison
   asciidoc:
     externals:
-    - spec: "asciidoc @9.1.0 %gcc@11 os=almalinux9"
+    - spec: "asciidoc @9.1.0 os=almalinux9"
       prefix: /usr
   autoconf:
     externals:
-    - spec: "autoconf @2.69 %gcc@11 os=almalinux9"
+    - spec: "autoconf @2.69 os=almalinux9"
       prefix: /usr
   automake:
     externals:
-    - spec: "automake @1.16.2 %gcc@11 os=almalinux9"
+    - spec: "automake @1.16.2 os=almalinux9"
       prefix: /usr
   berkeley-db:
     externals:
-    - spec: "berkeley-db @5.3.28 %gcc@11 os=almalinux9"
+    - spec: "berkeley-db @5.3.28 os=almalinux9"
       prefix: /usr
   binutils:
     externals:
-    - spec: "binutils +gas+gold+ld @2.35.2 %gcc@11 os=almalinux9"
+    - spec: "binutils +gas+gold+ld @2.35.2 os=almalinux9"
       prefix: /usr
   bison:
     externals:
-    - spec: "bison @3.7.4 %gcc@11 os=almalinux9"
+    - spec: "bison @3.7.4 os=almalinux9"
       prefix: /usr
   cigetcert:
     externals:
-    - spec: "cigetcert @1.21 %gcc@11 os=almalinux9"
+    - spec: "cigetcert @1.21 os=almalinux9"
       prefix: /usr
   cmake:
     externals:
-    - spec: "cmake ~ownlibs @3.20.2 %gcc@11 os=almalinux9"
+    - spec: "cmake ~ownlibs @3.20.2 os=almalinux9"
       prefix: /usr
   coreutils:
     externals:
-    - spec: "coreutils @8.32 %gcc@11 os=almalinux9"
+    - spec: "coreutils @8.32 os=almalinux9"
       prefix: /usr
   curl:
     externals:
-    - spec: "curl tls=openssl @7.76.1 %gcc@11 os=almalinux9"
+    - spec: "curl tls=openssl @7.76.1 os=almalinux9"
       prefix: /usr
   damageproto:
     externals:
-    - spec: "damageproto @1.1 %gcc@11 os=almalinux9"
+    - spec: "damageproto @1.1 os=almalinux9"
       prefix: /usr
     buildable: False
   diffutils:
     externals:
-    - spec: "diffutils @3.7 %gcc@11 os=almalinux9"
+    - spec: "diffutils @3.7 os=almalinux9"
       prefix: /usr
     buildable: False
   expat:
     externals:
-    - spec: "expat @2.5.0 %gcc@11 os=almalinux9"
+    - spec: "expat @2.5.0 os=almalinux9"
       prefix: /usr
     buildable: False
   findutils:
     externals:
-    - spec: "findutils @4.8.0 %gcc@11 os=almalinux9"
+    - spec: "findutils @4.8.0 os=almalinux9"
       prefix: /usr
     buildable: False
   flex:
     externals:
-    - spec: "flex @2.6.4 %gcc@11 os=almalinux9"
+    - spec: "flex @2.6.4 os=almalinux9"
       prefix: /usr
   fontconfig:
     externals:
-    - spec: "fontconfig @2.14.0 %gcc@11 os=almalinux9"
+    - spec: "fontconfig @2.14.0 os=almalinux9"
       prefix: /usr
   freetype:
     externals:
-    - spec: "freetype @2.10.4 %gcc@11 os=almalinux9"
+    - spec: "freetype @2.10.4 os=almalinux9"
       prefix: /usr
   gawk:
     externals:
-    - spec: "gawk @5.1.0 %gcc@11 os=almalinux9"
+    - spec: "gawk @5.1.0 os=almalinux9"
       prefix: /usr
   gdb:
     externals:
-    - spec: "gdb @10.2 %gcc@11 os=almalinux9"
+    - spec: "gdb @10.2 os=almalinux9"
       prefix: /usr
   gdbm:
     externals:
-    - spec: "gdbm @1.19 %gcc@11 os=almalinux9"
+    - spec: "gdbm @1.19 os=almalinux9"
       prefix: /usr
     buildable: False
   glib:
     externals:
-    - spec: "glib @2.68.4 %gcc@11 os=almalinux9"
+    - spec: "glib @2.68.4 os=almalinux9"
       prefix: /usr
     buildable: False
   gettext:
     externals:
-    - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.21 %gcc@11 os=almalinux9"
+    - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.21 os=almalinux9"
       prefix: /usr
     buildable: False
   git:
     externals:
-    - spec: "git @2.39.3 %gcc@11 os=almalinux9"
+    - spec: "git @2.39.3 os=almalinux9"
       prefix: /usr
   gtkplus:
     externals:
-    - spec: "gtkplus @3.24.31 %gcc@11 os=almalinux9"
+    - spec: "gtkplus @3.24.31 os=almalinux9"
       prefix: /usr
   gmake:
     externals:
-    - spec: "gmake @4.3 %gcc@11 os=almalinux9"
+    - spec: "gmake @4.3 os=almalinux9"
       prefix: /usr
   gperf:
     externals:
-    - spec: "gperf @3.1 %gcc@11 os=almalinux9"
+    - spec: "gperf @3.1 os=almalinux9"
       prefix: /usr
   groff:
     externals:
-    - spec: "groff @1.22.4 %gcc@11 os=almalinux9"
+    - spec: "groff @1.22.4 os=almalinux9"
       prefix: /usr
   help2man:
     externals:
-    - spec: "help2man @1.48.2 %gcc@11 os=almalinux9"
+    - spec: "help2man @1.48.2 os=almalinux9"
       prefix: /usr
   htcondor:
     externals:
-    - spec: "htcondor @A %gcc@11 os=almalinux9"
+    - spec: "htcondor @A os=almalinux9"
       prefix: /usr
   htgettoken:
     externals:
-    - spec: "htgettoken @1.20 %gcc@11 os=almalinux9"
+    - spec: "htgettoken @1.20 os=almalinux9"
       prefix: /usr
   hwloc:
     require:
@@ -187,16 +182,16 @@ packages:
         - "%clang@15.0.7"
   krb5:
     externals:
-    - spec: "krb5 @1.20.1 %gcc@11 os=almalinux9"
+    - spec: "krb5 @1.20.1 os=almalinux9"
       prefix: /usr
   libfontenc:
     externals:
-    - spec: "libfontenc @1.1.3 %gcc@11 os=almalinux9"
+    - spec: "libfontenc @1.1.3 os=almalinux9"
       prefix: /usr
     buildable: False
   libice:
     externals:
-    - spec: "libice @1.0.10 %gcc@11 os=almalinux9"
+    - spec: "libice @1.0.10 os=almalinux9"
       prefix: /usr
     buildable: False
   libpciaccess:
@@ -208,229 +203,229 @@ packages:
         - "%clang@15.0.7"
   libsm:
     externals:
-    - spec: "libsm @1.2.3 %gcc@11 os=almalinux9"
+    - spec: "libsm @1.2.3 os=almalinux9"
       prefix: /usr
   libtool:
     externals:
-    - spec: "libtool @2.4.6 %gcc@11 os=almalinux9"
+    - spec: "libtool @2.4.6 os=almalinux9"
       prefix: /usr
   libuuid:
     externals:
-    - spec: "libuuid @2.37.4 %gcc@11 os=almalinux9"
+    - spec: "libuuid @2.37.4 os=almalinux9"
       prefix: /usr
   libx11:
     externals:
-    - spec: "libx11 @1.7.0 %gcc@11 os=almalinux9"
+    - spec: "libx11 @1.7.0 os=almalinux9"
       prefix: /usr
     buildable: False
   libxau:
     externals:
-    - spec: "libxau @1.0.9 %gcc@11 os=almalinux9"
+    - spec: "libxau @1.0.9 os=almalinux9"
       prefix: /usr
     buildable: False
   libxcb:
     externals:
-    - spec: "libxcb @1.13.1 %gcc@11 os=almalinux9"
+    - spec: "libxcb @1.13.1 os=almalinux9"
       prefix: /usr
     buildable: False
   libxdmcp:
     externals:
-    - spec: "libxdmcp @1.1.3 %gcc@11 os=almalinux9"
+    - spec: "libxdmcp @1.1.3 os=almalinux9"
       prefix: /usr
     buildable: False
   libxext:
     externals:
-    - spec: "libxext @1.3.4 %gcc@11 os=almalinux9"
+    - spec: "libxext @1.3.4 os=almalinux9"
       prefix: /usr
     buildable: False
   libxft:
     externals:
-    - spec: "libxft @2.3.3 %gcc@11 os=almalinux9"
+    - spec: "libxft @2.3.3 os=almalinux9"
       prefix: /usr
   libxi:
     externals:
-    - spec: "libxi @1.7.10 %gcc@11 os=almalinux9"
+    - spec: "libxi @1.7.10 os=almalinux9"
       prefix: /usr
   libxkbcommon:
     externals:
-    - spec: "libxkbcommon @1.0.3 %gcc@11 os=almalinux9"
+    - spec: "libxkbcommon @1.0.3 os=almalinux9"
       prefix: /usr
     buildable: False
   libxml2:
     externals:
-    - spec: "libxml2 @2.9.13 %gcc@11 os=almalinux9"
+    - spec: "libxml2 @2.9.13 os=almalinux9"
       prefix: /usr
   libxmu:
     externals:
-    - spec: "libxmu @1.1.3 %gcc@11 os=almalinux9"
+    - spec: "libxmu @1.1.3 os=almalinux9"
       prefix: /usr
     buildable: False
   libxpm:
     externals:
-    - spec: "libxpm @3.5.13 %gcc@11 os=almalinux9"
+    - spec: "libxpm @3.5.13 os=almalinux9"
       prefix: /usr
     buildable: False
   libxrender:
     externals:
-    - spec: "libxrender @0.9.10 %gcc@11 os=almalinux9"
+    - spec: "libxrender @0.9.10 os=almalinux9"
       prefix: /usr
     buildable: False
   libxshmfence:
     externals:
-    - spec: "libxshmfence @1.3 %gcc@11 os=almalinux9"
+    - spec: "libxshmfence @1.3 os=almalinux9"
       prefix: /usr
     buildable: False
   libxt:
     externals:
-    - spec: "libxt @1.2.0 %gcc@11 os=almalinux9"
+    - spec: "libxt @1.2.0 os=almalinux9"
       prefix: /usr
     buildable: False
   libxv:
     externals:
-    - spec: "libxv @1.0.11 %gcc@11 os=almalinux9"
+    - spec: "libxv @1.0.11 os=almalinux9"
       prefix: /usr
     buildable: False
   libxxf86vm:
     externals:
-    - spec: "libxxf86vm @1.1.4 %gcc@11 os=almalinux9"
+    - spec: "libxxf86vm @1.1.4 os=almalinux9"
       prefix: /usr
     buildable: False
   lmod:
     externals:
-    - spec: "lmod @8.7.30 %gcc@11 os=almalinux9"
+    - spec: "lmod @8.7.30 os=almalinux9"
       prefix: /usr
   m4:
     externals:
-    - spec: "m4 @1.4.19 %gcc@11 os=almalinux9"
+    - spec: "m4 @1.4.19 os=almalinux9"
       prefix: /usr
   mesa-glu:
     externals:
-    - spec: "mesa-glu @9.0.1 %gcc@11 os=almalinux9"
+    - spec: "mesa-glu @9.0.1 os=almalinux9"
       prefix: /usr
     buildable: False
   mesa:
     externals:
-    - spec: "mesa +glx~osmesa swr=none @22.3.0 %gcc@11 os=almalinux9"
+    - spec: "mesa +glx~osmesa swr=none @22.3.0 os=almalinux9"
       prefix: /usr
   mkfontdir:
     externals:
-    - spec: "mkfontdir @1.2.1 %gcc@11 os=almalinux9"
+    - spec: "mkfontdir @1.2.1 os=almalinux9"
       prefix: /usr
     buildable: False
   mkfontscale:
     externals:
-    - spec: "mkfontscale @1.2.1 %gcc@11 os=almalinux9"
+    - spec: "mkfontscale @1.2.1 os=almalinux9"
       prefix: /usr
     buildable: False
   nasm:
     externals:
-    - spec: "nasm @2.15.03 %gcc@11 os=almalinux9"
+    - spec: "nasm @2.15.03 os=almalinux9"
       prefix: /usr
   ninja:
     externals:
-    - spec: "ninja @1.10.2 %gcc@11 os=almalinux9"
+    - spec: "ninja @1.10.2 os=almalinux9"
       prefix: /usr
   ncurses:
     externals:
-    - spec: "ncurses ~symlinks+termlib @6.2 %gcc@11 os=almalinux9"
+    - spec: "ncurses ~symlinks+termlib @6.2 os=almalinux9"
       prefix: /usr
   openssh:
     externals:
-    - spec: "openssh @8.7p1 %gcc@11 os=almalinux9"
+    - spec: "openssh @8.7p1 os=almalinux9"
       prefix: /usr
   openssl:
     externals:
-    - spec: "openssl @3.0.7 %gcc@11 os=almalinux9"
+    - spec: "openssl @3.0.7 os=almalinux9"
       prefix: /usr
   patchelf:
     externals:
-    - spec: "patchelf @0.15.0 %gcc@11 os=almalinux9"
+    - spec: "patchelf @0.15.0 os=almalinux9"
       prefix: /usr
   perl:
     externals:
-    - spec: "perl ~open~opcode @5.32.1 %gcc@11 os=almalinux9"
+    - spec: "perl ~open~opcode @5.32.1 os=almalinux9"
       prefix: /usr
   pkg-config:
     externals:
-    - spec: "pkg-config +internal_glib @1.7.3 %gcc@11 os=almalinux9"
+    - spec: "pkg-config +internal_glib @1.7.3 os=almalinux9"
       prefix: /usr
   pkgconf:
     externals:
-    - spec: "pkgconf @1.7.3 %gcc@11 os=almalinux9"
+    - spec: "pkgconf @1.7.3 os=almalinux9"
       prefix: /usr
   python:
     externals:
-    - spec: "python @3.9.18 %gcc@11 os=almalinux9"
+    - spec: "python @3.9.18 os=almalinux9"
       prefix: /usr
   readline:
     externals:
-    - spec: "readline @8.1 %gcc@11 os=almalinux9"
+    - spec: "readline @8.1 os=almalinux9"
       prefix: /usr
   tar:
     externals:
-    - spec: "tar @1.34 %gcc@11 os=almalinux9"
+    - spec: "tar @1.34 os=almalinux9"
       prefix: /usr
     buildable: False
   tcl:
     externals:
-    - spec: "tcl @8.6.10 %gcc@11 os=almalinux9"
+    - spec: "tcl @8.6.10 os=almalinux9"
       prefix: /usr
     buildable: False
   texinfo:
     externals:
-    - spec: "texinfo @6.7 %gcc@11 os=almalinux9"
+    - spec: "texinfo @6.7 os=almalinux9"
       prefix: /usr
   texlive:
     externals:
-    - spec: "texlive @20200406 %gcc@11 os=almalinux9"
+    - spec: "texlive @20200406 os=almalinux9"
       prefix: /usr
   tk:
     externals:
-    - spec: "tk @8.6.10 %gcc@11 os=almalinux9"
+    - spec: "tk @8.6.10 os=almalinux9"
       prefix: /usr
     buildable: False
   xcb-util-image:
     externals:
-    - spec: "xcb-util-image @0.4.0 %gcc@11 os=almalinux9"
+    - spec: "xcb-util-image @0.4.0 os=almalinux9"
       prefix: /usr
     buildable: False
   xcb-util-keysyms:
     externals:
-    - spec: "xcb-util-keysyms @0.4.0 %gcc@11 os=almalinux9"
+    - spec: "xcb-util-keysyms @0.4.0 os=almalinux9"
       prefix: /usr
     buildable: False
   xcb-util-renderutil:
     externals:
-    - spec: "xcb-util-renderutil @0.3.9 %gcc@11 os=almalinux9"
+    - spec: "xcb-util-renderutil @0.3.9 os=almalinux9"
       prefix: /usr
     buildable: False
   xcb-util-wm:
     externals:
-    - spec: "xcb-util-wm @0.4.1 %gcc@11 os=almalinux9"
+    - spec: "xcb-util-wm @0.4.1 os=almalinux9"
       prefix: /usr
     buildable: False
   xextproto:
     externals:
-    - spec: "xextproto @7.3.0 %gcc@11 os=almalinux9"
+    - spec: "xextproto @7.3.0 os=almalinux9"
       prefix: /usr
     buildable: False
   xproto:
     externals:
-    - spec: "xproto @7.0.33 %gcc@11 os=almalinux9"
+    - spec: "xproto @7.0.33 os=almalinux9"
       prefix: /usr
     buildable: False
   xrandr:
     externals:
-    - spec: "xrandr @1.5.0 %gcc@11 os=almalinux9"
+    - spec: "xrandr @1.5.0 os=almalinux9"
       prefix: /usr
     buildable: False
   xtrans:
     externals:
-    - spec: "xtrans @1.4.0 %gcc@11 os=almalinux9"
+    - spec: "xtrans @1.4.0 os=almalinux9"
       prefix: /usr
     buildable: False
   zlib:
     externals:
-    - spec: "zlib +optimize+pic+shared @1.2.11 %gcc@11 os=almalinux9"
+    - spec: "zlib +optimize+pic+shared @1.2.11 os=almalinux9"
       prefix: /usr
     buildable: False

--- a/scientific7/packages.yaml
+++ b/scientific7/packages.yaml
@@ -50,7 +50,6 @@ packages:
         - bison
   asciidoc:
     externals:
-<<<<<<< HEAD
     - spec: "asciidoc @8.6.8 os=scientific7"
       prefix: /usr
   autoconf:
@@ -68,30 +67,10 @@ packages:
   bdftopcf:
     externals:
     - spec: "bdftopcf @1.1 os=scientific7"
-=======
-    - spec: "asciidoc @8.6.8 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  autoconf:
-    externals:
-    - spec: "autoconf @2.69 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  autogen:
-    externals:
-    - spec: "autogen @5.18 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  automake:
-    externals:
-    - spec: "automake @1.13.4 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  bdftopcf:
-    externals:
-    - spec: "bdftopcf @1.1 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   berkeley-db:
     externals:
-<<<<<<< HEAD
     - spec: "berkeley-db @5.3.21 os=scientific7"
       prefix: /usr
   binutils:
@@ -117,82 +96,34 @@ packages:
   damageproto:
     externals:
     - spec: "damageproto @1.1 os=scientific7"
-=======
-    - spec: "berkeley-db @5.3.21 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  binutils:
-    externals:
-    - spec: "binutils +gas+gold+ld @2.27 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  bison:
-    externals:
-    - spec: "bison @3.0.4 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  cmake:
-    externals:
-    - spec: "cmake ~ownlibs @2.8.12.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  coreutils:
-    externals:
-    - spec: "coreutils @8.22 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  curl:
-    externals:
-    - spec: "curl @7.29.0 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  damageproto:
-    externals:
-    - spec: "damageproto @1.1 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   diffutils:
     externals:
-<<<<<<< HEAD
     - spec: "diffutils @3.3 os=scientific7"
-=======
-    - spec: "diffutils @3.3 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   expat:
     externals:
-<<<<<<< HEAD
     - spec: "expat @2.1.0 os=scientific7"
-=======
-    - spec: "expat @2.1.0 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   findutils:
     externals:
-<<<<<<< HEAD
     - spec: "findutils @4.5.11 os=scientific7"
-=======
-    - spec: "findutils @4.5.11 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   flex:
     externals:
-<<<<<<< HEAD
     - spec: "flex @2.5.37 os=scientific7"
       prefix: /usr
   font-util:
     externals:
     - spec: "font-util fonts=encodings @7.5 os=scientific7"
-=======
-    - spec: "flex @2.5.37 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  font-util:
-    externals:
-    - spec: "font-util fonts=encodings @7.5 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   fontconfig:
     externals:
-<<<<<<< HEAD
     - spec: "fontconfig @2.13.0 os=scientific7"
       prefix: /usr
   freetype:
@@ -210,56 +141,24 @@ packages:
   gdbm:
     externals:
     - spec: "gdbm @1.10 os=scientific7"
-=======
-    - spec: "fontconfig @2.13.0 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  freetype:
-    externals:
-    - spec: "freetype @2.8 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  gawk:
-    externals:
-    - spec: "gawk @4.0.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  gdb:
-    externals:
-    - spec: "gdb @7.6.1 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  gdbm:
-    externals:
-    - spec: "gdbm @1.10 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   gettext:
     externals:
-<<<<<<< HEAD
     - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.19.8.1 os=scientific7"
-=======
-    - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.19.8.1 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     # buildable: False
   git:
     externals:
-<<<<<<< HEAD
     - spec: "git @1.8.3.1 os=scientific7"
       prefix: /usr
   glib:
     externals:
     - spec: "glib @2.56.1 os=scientific7"
-=======
-    - spec: "git @1.8.3.1 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  glib:
-    externals:
-    - spec: "glib @2.56.1 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   gmake:
     externals:
-<<<<<<< HEAD
     - spec: "gmake @3.82 os=scientific7"
       prefix: /usr
   gperf:
@@ -273,21 +172,6 @@ packages:
   help2man:
     externals:
     - spec: "help2man @1.41.1 os=scientific7"
-=======
-    - spec: "gmake @3.82 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  gperf:
-    externals:
-    - spec: "gperf @3.0.4 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  groff:
-    externals:
-    - spec: "groff @1.22.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  help2man:
-    externals:
-    - spec: "help2man @1.41.1 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
   hwloc:
     require:
@@ -297,37 +181,21 @@ packages:
         - "%gcc@4.8.5"
   krb5:
     externals:
-<<<<<<< HEAD
     - spec: "krb5 @1.15.1 os=scientific7"
       prefix: /usr
   libc:
     externals:
     - spec: "libc +iconv+rpc @2.17 os=scientific7"
-=======
-    - spec: "krb5 @1.15.1 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  libc:
-    externals:
-    - spec: "libc +iconv+rpc @2.17 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libfontenc:
     externals:
-<<<<<<< HEAD
     - spec: "libfontenc @1.1.3 os=scientific7"
-=======
-    - spec: "libfontenc @1.1.3 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libice:
     externals:
-<<<<<<< HEAD
     - spec: "libice @1.0.9 os=scientific7"
-=======
-    - spec: "libice @1.0.9 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libpciaccess:
@@ -338,7 +206,6 @@ packages:
         - "%gcc@4.8.5"
   libsm:
     externals:
-<<<<<<< HEAD
     - spec: "libsm @1.2.2 os=scientific7"
       prefix: /usr
   libtool:
@@ -352,62 +219,30 @@ packages:
   libx11:
     externals:
     - spec: "libx11 @1.6.7 os=scientific7"
-=======
-    - spec: "libsm @1.2.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  libtool:
-    externals:
-    - spec: "libtool @2.4.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  libuuid:
-    externals:
-    - spec: "libuuid @2.23.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  libx11:
-    externals:
-    - spec: "libx11 @1.6.7 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxau:
     externals:
-<<<<<<< HEAD
     - spec: "libxau @1.0.8 os=scientific7"
-=======
-    - spec: "libxau @1.0.8 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxcb:
     externals:
-<<<<<<< HEAD
     - spec: "libxcb @1.13 os=scientific7"
-=======
-    - spec: "libxcb @1.13 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxdmcp:
     externals:
-<<<<<<< HEAD
     - spec: "libxdmcp @1.1.2 os=scientific7"
-=======
-    - spec: "libxdmcp @1.1.2 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxext:
     externals:
-<<<<<<< HEAD
     - spec: "libxext @1.3.3 os=scientific7"
-=======
-    - spec: "libxext @1.3.3 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxft:
     externals:
-<<<<<<< HEAD
     - spec: "libxft @2.3.2 os=scientific7"
       prefix: /usr
   libxi:
@@ -417,85 +252,45 @@ packages:
   libxmu:
     externals:
     - spec: "libxmu @1.1.2 os=scientific7"
-=======
-    - spec: "libxft @2.3.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  libxi:
-    externals:
-    - spec: "libxi @1.7.9 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  libxmu:
-    externals:
-    - spec: "libxmu @1.1.2 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxpm:
     externals:
-<<<<<<< HEAD
     - spec: "libxpm @3.5.12 os=scientific7"
-=======
-    - spec: "libxpm @3.5.12 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxrender:
     externals:
-<<<<<<< HEAD
     - spec: "libxrender @0.9.10 os=scientific7"
-=======
-    - spec: "libxrender @0.9.10 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxshmfence:
     externals:
-<<<<<<< HEAD
     - spec: "libxshmfence @1.2 os=scientific7"
-=======
-    - spec: "libxshmfence @1.2 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxt:
     externals:
-<<<<<<< HEAD
     - spec: "libxt @1.1.5 os=scientific7"
-=======
-    - spec: "libxt @1.1.5 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxv:
     externals:
-<<<<<<< HEAD
     - spec: "libxv @1.0.11 os=scientific7"
-=======
-    - spec: "libxv @1.0.11 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxvmc:
     externals:
-<<<<<<< HEAD
     - spec: "libxvmc @1.0.10 os=scientific7"
-=======
-    - spec: "libxvmc @1.0.10 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   libxxf86vm:
     externals:
-<<<<<<< HEAD
     - spec: "libxxf86vm @1.1.4 os=scientific7"
-=======
-    - spec: "libxxf86vm @1.1.4 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   lmod:
     externals:
-<<<<<<< HEAD
     - spec: "lmod @8.7.7 os=scientific7"
       prefix: /usr
   m4:
@@ -505,48 +300,24 @@ packages:
   mesa-glu:
     externals:
     - spec: "mesa-glu gl=glx @9.0.0 os=scientific7"
-=======
-    - spec: "lmod @8.7.7 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  m4:
-    externals:
-    - spec: "m4 @1.4.16 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  mesa-glu:
-    externals:
-    - spec: "mesa-glu gl=glx @9.0.0 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   mesa:
     externals:
-<<<<<<< HEAD
     - spec: "mesa +glx~osmesa swr=none @18.3.4 os=scientific7"
       prefix: /usr
   mkfontdir:
     externals:
     - spec: "mkfontdir @7.5 os=scientific7"
-=======
-    - spec: "mesa +glx~osmesa swr=none @18.3.4 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  mkfontdir:
-    externals:
-    - spec: "mkfontdir @7.5 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   mkfontscale:
     externals:
-<<<<<<< HEAD
     - spec: "mkfontscale @7.5 os=scientific7"
-=======
-    - spec: "mkfontscale @7.5 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   mpich:
     externals:
-<<<<<<< HEAD
     - spec: "mpich @3.2 os=scientific7"
       prefix: /usr/lib64/mpich-3.2/
   nasm:
@@ -592,67 +363,15 @@ packages:
   tar:
     externals:
     - spec: "tar @1.26 os=scientific7"
-=======
-    - spec: "mpich @3.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr/lib64/mpich-3.2/
-  nasm:
-    externals:
-    - spec: "nasm @2.10.07 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  ninja:
-    externals:
-    - spec: "ninja @1.10.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  ncurses:
-    externals:
-    - spec: "ncurses ~symlinks+termlib @5.9 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  openssh:
-    externals:
-    - spec: "openssh @7.4p1 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  openssl:
-    externals:
-    - spec: "openssl @1.0.2k os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  patchelf:
-    externals:
-    - spec: "patchelf @0.12 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  perl:
-    externals:
-    - spec: "perl @5.16.3 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  pkg-config:
-    externals:
-    - spec: "pkg-config +internal_glib @0.27.1 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  python:
-    externals:
-    - spec: "python @3.6.8 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  readline:
-    externals:
-    - spec: "readline @6.2 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  tar:
-    externals:
-    - spec: "tar @1.26 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   tcl:
     externals:
-<<<<<<< HEAD
     - spec: "tcl @8.5.13 os=scientific7"
-=======
-    - spec: "tcl @8.5.13 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   texinfo:
     externals:
-<<<<<<< HEAD
     - spec: "texinfo @5.1 os=scientific7"
       prefix: /usr
   texlive:
@@ -664,90 +383,45 @@ packages:
   tk:
     externals:
     - spec: "tk @8.5.13 os=scientific7"
-=======
-    - spec: "texinfo @5.1 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  texlive:
-    externals:
-    - spec: "texlive @2012-45 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-    - spec: "texlive @20220321 os=scientific7 %gcc@4.8.5"
-      prefix: /usr
-  tk:
-    externals:
-    - spec: "tk @8.5.13 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   xcb-util-keysyms:
     externals:
-<<<<<<< HEAD
     - spec: "xcb-util-keysyms @0.4.0 os=scientific7"
-=======
-    - spec: "xcb-util-keysyms @0.4.0 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   xcb-util-renderutil:
     externals:
-<<<<<<< HEAD
     - spec: "xcb-util-renderutil @0.3.9 os=scientific7"
-=======
-    - spec: "xcb-util-renderutil @0.3.9 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   xextproto:
     externals:
-<<<<<<< HEAD
     - spec: "xextproto @7.3.0 os=scientific7"
-=======
-    - spec: "xextproto @7.3.0 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   xorg-server:
     externals:
-<<<<<<< HEAD
     - spec: "xorg-server @1.20.4 os=scientific7"
-=======
-    - spec: "xorg-server @1.20.4 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   xproto:
     externals:
-<<<<<<< HEAD
     - spec: "xproto @7.0.32 os=scientific7"
-=======
-    - spec: "xproto @7.0.32 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   xrandr:
     externals:
-<<<<<<< HEAD
     - spec: "xrandr @1.5.0 os=scientific7"
-=======
-    - spec: "xrandr @1.5.0 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   xtrans:
     externals:
-<<<<<<< HEAD
     - spec: "xtrans @1.3.5 os=scientific7"
-=======
-    - spec: "xtrans @1.3.5 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False
   zlib:
     externals:
-<<<<<<< HEAD
     - spec: "zlib +optimize+pic+shared @1.2.7 os=scientific7"
-=======
-    - spec: "zlib +optimize+pic+shared @1.2.7 os=scientific7 %gcc@4.8.5"
->>>>>>> main
       prefix: /usr
     buildable: False

--- a/scientific7/packages.yaml
+++ b/scientific7/packages.yaml
@@ -1,9 +1,5 @@
 packages:
   all:
-    compiler:
-      - gcc@4.8.5
-      - gcc
-      - clang
     target:
       - x86_64_v2
     providers:
@@ -54,128 +50,128 @@ packages:
         - bison
   asciidoc:
     externals:
-    - spec: "asciidoc @8.6.8 %gcc@4.8.5 os=scientific7"
+    - spec: "asciidoc @8.6.8 os=scientific7"
       prefix: /usr
   autoconf:
     externals:
-    - spec: "autoconf @2.69 %gcc@4.8.5 os=scientific7"
+    - spec: "autoconf @2.69 os=scientific7"
       prefix: /usr
   autogen:
     externals:
-    - spec: "autogen @5.18 %gcc@4.8.5 os=scientific7"
+    - spec: "autogen @5.18 os=scientific7"
       prefix: /usr
   automake:
     externals:
-    - spec: "automake @1.13.4 %gcc@4.8.5 os=scientific7"
+    - spec: "automake @1.13.4 os=scientific7"
       prefix: /usr
   bdftopcf:
     externals:
-    - spec: "bdftopcf @1.1 %gcc@4.8.5 os=scientific7"
+    - spec: "bdftopcf @1.1 os=scientific7"
       prefix: /usr
     buildable: False
   berkeley-db:
     externals:
-    - spec: "berkeley-db @5.3.21 %gcc@4.8.5 os=scientific7"
+    - spec: "berkeley-db @5.3.21 os=scientific7"
       prefix: /usr
   binutils:
     externals:
-    - spec: "binutils +gas+gold+ld @2.27 %gcc@4.8.5 os=scientific7"
+    - spec: "binutils +gas+gold+ld @2.27 os=scientific7"
       prefix: /usr
   bison:
     externals:
-    - spec: "bison @3.0.4 %gcc@4.8.5 os=scientific7"
+    - spec: "bison @3.0.4 os=scientific7"
       prefix: /usr
   cmake:
     externals:
-    - spec: "cmake ~ownlibs @2.8.12.2 %gcc@4.8.5 os=scientific7"
+    - spec: "cmake ~ownlibs @2.8.12.2 os=scientific7"
       prefix: /usr
   coreutils:
     externals:
-    - spec: "coreutils @8.22 %gcc@4.8.5 os=scientific7"
+    - spec: "coreutils @8.22 os=scientific7"
       prefix: /usr
   curl:
     externals:
-    - spec: "curl @7.29.0 %gcc@4.8.5 os=scientific7"
+    - spec: "curl @7.29.0 os=scientific7"
       prefix: /usr
   damageproto:
     externals:
-    - spec: "damageproto @1.1 %gcc@4.8.5 os=scientific7"
+    - spec: "damageproto @1.1 os=scientific7"
       prefix: /usr
     buildable: False
   diffutils:
     externals:
-    - spec: "diffutils @3.3 %gcc@4.8.5 os=scientific7"
+    - spec: "diffutils @3.3 os=scientific7"
       prefix: /usr
     buildable: False
   expat:
     externals:
-    - spec: "expat @2.1.0 %gcc@4.8.5 os=scientific7"
+    - spec: "expat @2.1.0 os=scientific7"
       prefix: /usr
     buildable: False
   findutils:
     externals:
-    - spec: "findutils @4.5.11 %gcc@4.8.5 os=scientific7"
+    - spec: "findutils @4.5.11 os=scientific7"
       prefix: /usr
     buildable: False
   flex:
     externals:
-    - spec: "flex @2.5.37 %gcc@4.8.5 os=scientific7"
+    - spec: "flex @2.5.37 os=scientific7"
       prefix: /usr
   font-util:
     externals:
-    - spec: "font-util fonts=encodings @7.5 %gcc@4.8.5 os=scientific7"
+    - spec: "font-util fonts=encodings @7.5 os=scientific7"
       prefix: /usr
     buildable: False
   fontconfig:
     externals:
-    - spec: "fontconfig @2.13.0 %gcc@4.8.5 os=scientific7"
+    - spec: "fontconfig @2.13.0 os=scientific7"
       prefix: /usr
   freetype:
     externals:
-    - spec: "freetype @2.8 %gcc@4.8.5 os=scientific7"
+    - spec: "freetype @2.8 os=scientific7"
       prefix: /usr
   gawk:
     externals:
-    - spec: "gawk @4.0.2 %gcc@4.8.5 os=scientific7"
+    - spec: "gawk @4.0.2 os=scientific7"
       prefix: /usr
   gdb:
     externals:
-    - spec: "gdb @7.6.1 %gcc@4.8.5 os=scientific7"
+    - spec: "gdb @7.6.1 os=scientific7"
       prefix: /usr
   gdbm:
     externals:
-    - spec: "gdbm @1.10 %gcc@4.8.5 os=scientific7"
+    - spec: "gdbm @1.10 os=scientific7"
       prefix: /usr
     buildable: False
   gettext:
     externals:
-    - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.19.8.1 %gcc@4.8.5 os=scientific7"
+    - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.19.8.1 os=scientific7"
       prefix: /usr
     # buildable: False
   git:
     externals:
-    - spec: "git @1.8.3.1 %gcc@4.8.5 os=scientific7"
+    - spec: "git @1.8.3.1 os=scientific7"
       prefix: /usr
   glib:
     externals:
-    - spec: "glib @2.56.1 %gcc@4.8.5 os=scientific7"
+    - spec: "glib @2.56.1 os=scientific7"
       prefix: /usr
     buildable: False
   gmake:
     externals:
-    - spec: "gmake @3.82 %gcc@4.8.5 os=scientific7"
+    - spec: "gmake @3.82 os=scientific7"
       prefix: /usr
   gperf:
     externals:
-    - spec: "gperf @3.0.4 %gcc@4.8.5 os=scientific7"
+    - spec: "gperf @3.0.4 os=scientific7"
       prefix: /usr
   groff:
     externals:
-    - spec: "groff @1.22.2 %gcc@4.8.5 os=scientific7"
+    - spec: "groff @1.22.2 os=scientific7"
       prefix: /usr
   help2man:
     externals:
-    - spec: "help2man @1.41.1 %gcc@4.8.5 os=scientific7"
+    - spec: "help2man @1.41.1 os=scientific7"
       prefix: /usr
   hwloc:
     require:
@@ -185,21 +181,21 @@ packages:
         - "%gcc@4.8.5"
   krb5:
     externals:
-    - spec: "krb5 @1.15.1 %gcc@4.8.5 os=scientific7"
+    - spec: "krb5 @1.15.1 os=scientific7"
       prefix: /usr
   libc:
     externals:
-    - spec: "libc +iconv+rpc @2.17 %gcc@4.8.5 os=scientific7"
+    - spec: "libc +iconv+rpc @2.17 os=scientific7"
       prefix: /usr
     buildable: False
   libfontenc:
     externals:
-    - spec: "libfontenc @1.1.3 %gcc@4.8.5 os=scientific7"
+    - spec: "libfontenc @1.1.3 os=scientific7"
       prefix: /usr
     buildable: False
   libice:
     externals:
-    - spec: "libice @1.0.9 %gcc@4.8.5 os=scientific7"
+    - spec: "libice @1.0.9 os=scientific7"
       prefix: /usr
     buildable: False
   libpciaccess:
@@ -210,222 +206,222 @@ packages:
         - "%gcc@4.8.5"
   libsm:
     externals:
-    - spec: "libsm @1.2.2 %gcc@4.8.5 os=scientific7"
+    - spec: "libsm @1.2.2 os=scientific7"
       prefix: /usr
   libtool:
     externals:
-    - spec: "libtool @2.4.2 %gcc@4.8.5 os=scientific7"
+    - spec: "libtool @2.4.2 os=scientific7"
       prefix: /usr
   libuuid:
     externals:
-    - spec: "libuuid @2.23.2 %gcc@4.8.5 os=scientific7"
+    - spec: "libuuid @2.23.2 os=scientific7"
       prefix: /usr
   libx11:
     externals:
-    - spec: "libx11 @1.6.7 %gcc@4.8.5 os=scientific7"
+    - spec: "libx11 @1.6.7 os=scientific7"
       prefix: /usr
     buildable: False
   libxau:
     externals:
-    - spec: "libxau @1.0.8 %gcc@4.8.5 os=scientific7"
+    - spec: "libxau @1.0.8 os=scientific7"
       prefix: /usr
     buildable: False
   libxcb:
     externals:
-    - spec: "libxcb @1.13 %gcc@4.8.5 os=scientific7"
+    - spec: "libxcb @1.13 os=scientific7"
       prefix: /usr
     buildable: False
   libxdmcp:
     externals:
-    - spec: "libxdmcp @1.1.2 %gcc@4.8.5 os=scientific7"
+    - spec: "libxdmcp @1.1.2 os=scientific7"
       prefix: /usr
     buildable: False
   libxext:
     externals:
-    - spec: "libxext @1.3.3 %gcc@4.8.5 os=scientific7"
+    - spec: "libxext @1.3.3 os=scientific7"
       prefix: /usr
     buildable: False
   libxft:
     externals:
-    - spec: "libxft @2.3.2 %gcc@4.8.5 os=scientific7"
+    - spec: "libxft @2.3.2 os=scientific7"
       prefix: /usr
   libxi:
     externals:
-    - spec: "libxi @1.7.9 %gcc@4.8.5 os=scientific7"
+    - spec: "libxi @1.7.9 os=scientific7"
       prefix: /usr
   libxmu:
     externals:
-    - spec: "libxmu @1.1.2 %gcc@4.8.5 os=scientific7"
+    - spec: "libxmu @1.1.2 os=scientific7"
       prefix: /usr
     buildable: False
   libxpm:
     externals:
-    - spec: "libxpm @3.5.12 %gcc@4.8.5 os=scientific7"
+    - spec: "libxpm @3.5.12 os=scientific7"
       prefix: /usr
     buildable: False
   libxrender:
     externals:
-    - spec: "libxrender @0.9.10 %gcc@4.8.5 os=scientific7"
+    - spec: "libxrender @0.9.10 os=scientific7"
       prefix: /usr
     buildable: False
   libxshmfence:
     externals:
-    - spec: "libxshmfence @1.2 %gcc@4.8.5 os=scientific7"
+    - spec: "libxshmfence @1.2 os=scientific7"
       prefix: /usr
     buildable: False
   libxt:
     externals:
-    - spec: "libxt @1.1.5 %gcc@4.8.5 os=scientific7"
+    - spec: "libxt @1.1.5 os=scientific7"
       prefix: /usr
     buildable: False
   libxv:
     externals:
-    - spec: "libxv @1.0.11 %gcc@4.8.5 os=scientific7"
+    - spec: "libxv @1.0.11 os=scientific7"
       prefix: /usr
     buildable: False
   libxvmc:
     externals:
-    - spec: "libxvmc @1.0.10 %gcc@4.8.5 os=scientific7"
+    - spec: "libxvmc @1.0.10 os=scientific7"
       prefix: /usr
     buildable: False
   libxxf86vm:
     externals:
-    - spec: "libxxf86vm @1.1.4 %gcc@4.8.5 os=scientific7"
+    - spec: "libxxf86vm @1.1.4 os=scientific7"
       prefix: /usr
     buildable: False
   lmod:
     externals:
-    - spec: "lmod @8.7.7 %gcc@4.8.5 os=scientific7"
+    - spec: "lmod @8.7.7 os=scientific7"
       prefix: /usr
   m4:
     externals:
-    - spec: "m4 @1.4.16 %gcc@4.8.5 os=scientific7"
+    - spec: "m4 @1.4.16 os=scientific7"
       prefix: /usr
   mesa-glu:
     externals:
-    - spec: "mesa-glu gl=glx @9.0.0 %gcc@4.8.5 os=scientific7"
+    - spec: "mesa-glu gl=glx @9.0.0 os=scientific7"
       prefix: /usr
     buildable: False
   mesa:
     externals:
-    - spec: "mesa +glx~osmesa swr=none @18.3.4 %gcc@4.8.5 os=scientific7"
+    - spec: "mesa +glx~osmesa swr=none @18.3.4 os=scientific7"
       prefix: /usr
   mkfontdir:
     externals:
-    - spec: "mkfontdir @7.5 %gcc@4.8.5 os=scientific7"
+    - spec: "mkfontdir @7.5 os=scientific7"
       prefix: /usr
     buildable: False
   mkfontscale:
     externals:
-    - spec: "mkfontscale @7.5 %gcc@4.8.5 os=scientific7"
+    - spec: "mkfontscale @7.5 os=scientific7"
       prefix: /usr
     buildable: False
   mpich:
     externals:
-    - spec: "mpich @3.2 %gcc@4.8.5 os=scientific7"
+    - spec: "mpich @3.2 os=scientific7"
       prefix: /usr/lib64/mpich-3.2/
   nasm:
     externals:
-    - spec: "nasm @2.10.07 %gcc@4.8.5 os=scientific7"
+    - spec: "nasm @2.10.07 os=scientific7"
       prefix: /usr
   ninja:
     externals:
-    - spec: "ninja @1.10.2 %gcc@4.8.5 os=scientific7"
+    - spec: "ninja @1.10.2 os=scientific7"
       prefix: /usr
   ncurses:
     externals:
-    - spec: "ncurses ~symlinks+termlib @5.9 %gcc@4.8.5 os=scientific7"
+    - spec: "ncurses ~symlinks+termlib @5.9 os=scientific7"
       prefix: /usr
   openssh:
     externals:
-    - spec: "openssh @7.4p1 %gcc@4.8.5 os=scientific7"
+    - spec: "openssh @7.4p1 os=scientific7"
       prefix: /usr
   openssl:
     externals:
-    - spec: "openssl @1.0.2k %gcc@4.8.5 os=scientific7"
+    - spec: "openssl @1.0.2k os=scientific7"
       prefix: /usr
   patchelf:
     externals:
-    - spec: "patchelf @0.12 %gcc@4.8.5 os=scientific7"
+    - spec: "patchelf @0.12 os=scientific7"
       prefix: /usr
   perl:
     externals:
-    - spec: "perl @5.16.3 %gcc@4.8.5 os=scientific7"
+    - spec: "perl @5.16.3 os=scientific7"
       prefix: /usr
   pkg-config:
     externals:
-    - spec: "pkg-config +internal_glib @0.27.1 %gcc@4.8.5 os=scientific7"
+    - spec: "pkg-config +internal_glib @0.27.1 os=scientific7"
       prefix: /usr
   python:
     externals:
-    - spec: "python @3.6.8 %gcc@4.8.5 os=scientific7"
+    - spec: "python @3.6.8 os=scientific7"
       prefix: /usr
   readline:
     externals:
-    - spec: "readline @6.2 %gcc@4.8.5 os=scientific7"
+    - spec: "readline @6.2 os=scientific7"
       prefix: /usr
   tar:
     externals:
-    - spec: "tar @1.26 %gcc@4.8.5 os=scientific7"
+    - spec: "tar @1.26 os=scientific7"
       prefix: /usr
     buildable: False
   tcl:
     externals:
-    - spec: "tcl @8.5.13 %gcc@4.8.5 os=scientific7"
+    - spec: "tcl @8.5.13 os=scientific7"
       prefix: /usr
     buildable: False
   texinfo:
     externals:
-    - spec: "texinfo @5.1 %gcc@4.8.5 os=scientific7"
+    - spec: "texinfo @5.1 os=scientific7"
       prefix: /usr
   texlive:
     externals:
-    - spec: "texlive @2012-45 %gcc@4.8.5 os=scientific7"
+    - spec: "texlive @2012-45 os=scientific7"
       prefix: /usr
-    - spec: "texlive @20220321 %gcc@4.8.5 os=scientific7"
+    - spec: "texlive @20220321 os=scientific7"
       prefix: /usr
   tk:
     externals:
-    - spec: "tk @8.5.13 %gcc@4.8.5 os=scientific7"
+    - spec: "tk @8.5.13 os=scientific7"
       prefix: /usr
     buildable: False
   xcb-util-keysyms:
     externals:
-    - spec: "xcb-util-keysyms @0.4.0 %gcc@4.8.5 os=scientific7"
+    - spec: "xcb-util-keysyms @0.4.0 os=scientific7"
       prefix: /usr
     buildable: False
   xcb-util-renderutil:
     externals:
-    - spec: "xcb-util-renderutil @0.3.9 %gcc@4.8.5 os=scientific7"
+    - spec: "xcb-util-renderutil @0.3.9 os=scientific7"
       prefix: /usr
     buildable: False
   xextproto:
     externals:
-    - spec: "xextproto @7.3.0 %gcc@4.8.5 os=scientific7"
+    - spec: "xextproto @7.3.0 os=scientific7"
       prefix: /usr
     buildable: False
   xorg-server:
     externals:
-    - spec: "xorg-server @1.20.4 %gcc@4.8.5 os=scientific7"
+    - spec: "xorg-server @1.20.4 os=scientific7"
       prefix: /usr
     buildable: False
   xproto:
     externals:
-    - spec: "xproto @7.0.32 %gcc@4.8.5 os=scientific7"
+    - spec: "xproto @7.0.32 os=scientific7"
       prefix: /usr
     buildable: False
   xrandr:
     externals:
-    - spec: "xrandr @1.5.0 %gcc@4.8.5 os=scientific7"
+    - spec: "xrandr @1.5.0 os=scientific7"
       prefix: /usr
     buildable: False
   xtrans:
     externals:
-    - spec: "xtrans @1.3.5 %gcc@4.8.5 os=scientific7"
+    - spec: "xtrans @1.3.5 os=scientific7"
       prefix: /usr
     buildable: False
   zlib:
     externals:
-    - spec: "zlib +optimize+pic+shared @1.2.7 %gcc@4.8.5 os=scientific7"
+    - spec: "zlib +optimize+pic+shared @1.2.7 os=scientific7"
       prefix: /usr
     buildable: False


### PR DESCRIPTION
... for spack 1.x releases, which do *not* like it. 