### PR TITLE
add default branch attribute for package repos

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -2,26 +2,36 @@ repos:
   sbn-spack:
     git: https://github.com/gartung/sbn-spack.git
     destination: $spack/var/spack/repos/sbn-spack
+    branch: spack-v1.0
   wirecell:
     git: https://github.com/gartung/wire-cell-spack
     destination: $spack/var/spack/repos/wire-cell-spack
+    branch: master
   dune_spack:
     git: https://github.com/DUNE/dune_spack.git
     destination: $spack/var/spack/repos/dune_spack
+    branch: spack-v1.0
   nusoft:
     git: https://github.com/gartung/nusofthep-spack-recipes.git
     destination: $spack/var/spack/repos/nusofthep-spack-recipes
+    branch: spack-v1.0
   larsoft:
     git: https://github.com/LArSoft/larsoft-spack-recipes.git
     destination: $spack/var/spack/repos/larsoft-spack-recipes
+    branch: main
   fnal_art:
     git: https://github.com/FNALssi/fnal_art.git
     destination: $spack/var/spack/repos/fnal_art
+    branch: develop
   artdaq_spack:
     git: https://github.com/art-daq/artdaq-spack.git
     destination: $spack/var/spack/repos/artdaq-spack
+    branch: Spack1.0
   scd_recipes:
     git: https://github.com/fnal-fife/scd_recipes.git
     destination: $spack/var/spack/repos/scd_recipes
+    branch: master
   builtin:
+    git: https://github.com/FNALssi/spack-packages.git
     destination: $spack/var/spack/repos/builtin
+    branch: fnal-develop


### PR DESCRIPTION
This PR populates the `branch` attribute in the default `repos.yaml` config, and also explicitly states the git remote for the `builtin` repo. The branches used for each package are consistent with those used in the `make_spack` executable in `fermi-spack-tools` [here](https://github.com/FNALssi/fermi-spack-tools/blob/0ce10b4091f6bcdab7e518c1fc704dc05c000e73/bin/make_spack#L97-L115).

Accurately setting the branch for each spack repo enables the use of `spack repo update` to update package repositories. Since `make_spack` manually clones the package repos, Spack's record of which remote and branch to fetch each package repo from is incomplete in the existing workflow. This PR resolves that issue.

I've also confirmed that adding this information to `repos.yaml` means that manually cloning package repos in `make_spack` is no longer necessary – Spack will use this updated `repos.yaml` to automatically fetch the package repos from their respective remote repositories when it's initialized. In a local test, I updated `make_spack` to fetch this updated version of `repos.yaml` from my fork of `fermi-etc-spack-linux`, and then removed the package repos from the list of repositories that `make_spack`clones. If it's desired, I can submit a follow-up PR to `fermi-spack-tools` to make that change there -- although this PR doesn't depend on that change being made subsequently.