### PR TITLE
Remove system python and python-dependent externals

### DIFF
--- a/almalinux9/packages.yaml
+++ b/almalinux9/packages.yaml
@@ -50,14 +50,6 @@ packages:
       - libuuid
       yacc:
       - bison
-  asciidoc:
-    externals:
-    - spec: asciidoc @9.1.0 os=almalinux9
-      prefix: /usr
-      dependencies:
-      - id: system_python
-        deptypes: ["build", "run"]
-    buildable: false
   autoconf:
     externals:
     - spec: autoconf @2.69 os=almalinux9
@@ -72,14 +64,6 @@ packages:
     externals:
     - spec: bdftopcf @1.1.2 os=almalinux9
       prefix: /usr
-    buildable: false
-  cigetcert:
-    externals:
-    - spec: cigetcert @1.21 os=almalinux9
-      prefix: /usr
-      dependencies:
-      - id: system_python
-        deptypes: ["build", "run"]
     buildable: false
   coreutils:
     externals:
@@ -175,14 +159,6 @@ packages:
     externals:
     - spec: htcondor @23.0.26 os=almalinux9
       prefix: /usr
-    buildable: false
-  htgettoken:
-    externals:
-    - spec: htgettoken @2.2 os=almalinux9
-      prefix: /usr
-      dependencies:
-      - id: system_python
-        deptypes: ["build", "run"]
     buildable: false
   hwloc:
     externals:
@@ -353,12 +329,6 @@ packages:
     externals:
     - spec: perl @5.32.1 os=almalinux9
       prefix: /usr
-    buildable: false
-  python:
-    externals:
-    - spec: python @3.9.23 os=almalinux9
-      prefix: /usr
-      id: system_python
     buildable: false
   pkg-config:
     externals:


### PR DESCRIPTION
Credit to @gartung for making these changes (https://github.com/FNALssi/fermi-etc-spack-linux/commit/7abf7be918761924cd884484b28724a8d535a045)